### PR TITLE
inactive 시 웹뷰 핸들링

### DIFF
--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -73,6 +73,7 @@ const HomeScreen = () => {
           onLoad={onWebViewLoad}
           onError={onWebViewError}
           onMessage={onMessage}
+          onContentProcessDidTerminate={() => webViewRef.current?.reload()}
         />
       </SafeAreaView>
     </>


### PR DESCRIPTION
<!-- 작성 예시 -->
<!-- # 해결하려는 문제가 무엇인가요? -->
<!-- - React v18 version update에 후 테스트에서 에러가 발생합니다.
  react-testing-library의 버전이 호환이 되지않아서 문제입니다. -->

<!-- # 어떻게 해결했나요? -->
<!-- - react-testing-library의 버전을 업데이트하고, react-test-renderer를 v18을 사용할 수 있도록 dev dependency로 설치해주었습니다. -->

## 🤔 해결하려는 문제가 무엇인가요?

앱이 inactive 상태에 돌입 후 다시 앱을 실행하면 웹뷰를 로드하지 못해요

## 🎉 어떻게 해결했나요?

- `onContentProcessDidTerminate` 스펙을 이용해 웹뷰를 리로드하도록 했어요

### 📚 Attachment (Option)

<!-- - 이번 PR 의 Front 동작을 이해를 돕는 GIF 파일 첨부!
- 리뷰어의 이해를 돕기 위한 모듈/클래스 설계에 대한 Diagram 포함! -->

iOS의 웹뷰는 별도의 프로세스를 사용해 렌더링하고 관리한다는데

웹뷰가 총 램에 포함되지 않아 새 앱의 메모리를 확보하기 위해 앱과 독립적으로 종료될 수 있다고 합니다

그래서 발생한 이슈 같아용

https://github.com/react-native-webview/react-native-webview/blob/master/docs/Reference.md#oncontentprocessdidterminate
https://github.com/react-native-webview/react-native-webview/issues/2298
